### PR TITLE
Fix subproperty parsing for linux-systems

### DIFF
--- a/icalendar.h
+++ b/icalendar.h
@@ -41,7 +41,7 @@ private:
 		if (Pos == string::npos)
 			return "";
 		Pos += strlen(SubProperty) + 1;
-		return Line.substr(Pos, Line.find_first_of(';', Pos)-Pos);
+		return Line.substr(Pos, Line.find_first_of(";\r", Pos)-Pos);
 	}
 	void FixLineEnd(string &Line, unsigned int Length) {
 		if (Length > 0 && Line[Length-1] == '\r')


### PR DESCRIPTION
When setting up a simple daily rrule, the .ics format for the RRULE line looks like this:

RRULE:FREQ=DAILY\r\n

Now when line 63 of icalendar.cpp
`NewEvent->RRule.Freq = ConvertFrequency(GetSubProperty(Line, "FREQ"));`
tries to get its sub property, find_first_of looked for a ';', couldn't find it, returned string::npos (-1) and subtracted the position of the subproperty.
So you ended up with Line.substr(Pos, -11) for example. In this case, Line.substr returns from Pos to the end of the line, including '\r’. Now I didn't test this on a windows system, but on my Linux this breaks ConvertFrequency as it can't handle "DAILY\r", defaulting to YEAR. It may have always worked on windows/mac as they end substr at \r(\n).

This PR should fix this.